### PR TITLE
feat: normalize schema type

### DIFF
--- a/components/groups/endpoints/create-form.tsx
+++ b/components/groups/endpoints/create-form.tsx
@@ -7,7 +7,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { useFieldArray, useForm } from "react-hook-form";
 
-import { validationOptions } from "@/lib/validation";
+import { normalizedValidationOption, validationOptions } from "@/lib/validation";
 import { createEndpointFormSchema as formSchema } from "@/lib/data/validations";
 
 // next imports
@@ -136,7 +136,7 @@ export default function CreateForm() {
                         <SelectContent>
                           {validationOptions.map((type, index: number) => (
                             <SelectItem key={index} value={type.name}>
-                              {type.name}
+                              {normalizedValidationOption[type.name]}
                             </SelectItem>
                           ))}
                         </SelectContent>

--- a/components/groups/endpoints/edit-form.tsx
+++ b/components/groups/endpoints/edit-form.tsx
@@ -8,7 +8,7 @@ import * as z from "zod";
 import { useFieldArray, useForm } from "react-hook-form";
 import { updateEndpointFormSchema as formSchema } from "@/lib/data/validations";
 
-import { validationOptions } from "@/lib/validation";
+import { normalizedValidationOption, validationOptions } from "@/lib/validation";
 
 // next imports
 import { useRouter } from "next/navigation";
@@ -143,7 +143,7 @@ export default function EditForm({
                         <SelectContent>
                           {validationOptions.map((type, index: number) => (
                             <SelectItem key={index} value={type.name}>
-                              {type.name}
+                              {normalizedValidationOption[type.name]}
                             </SelectItem>
                           ))}
                         </SelectContent>

--- a/lib/validation/index.ts
+++ b/lib/validation/index.ts
@@ -21,6 +21,17 @@ export const validationOptions: { name: ValidationType }[] = [
   { name: "zip_code" },
 ];
 
+export const normalizedValidationOption = {
+  phone: "Phone Number",
+  email: "E-Mail Address",
+  string: "String",
+  number: "Number",
+  date: "Date",
+  boolean: "Boolean",
+  url: "URL",
+  zip_code: "Zip Code",
+}
+
 /**
  * Zod validations for each validation type
  *

--- a/lib/validation/index.ts
+++ b/lib/validation/index.ts
@@ -9,6 +9,7 @@ import validator from "validator";
  * 1. add a key value pair in 'validationOptions' of the new validation type
  * 2. Add a zod schema definition in the 'validations' object in this file
  * 3. If necessary, add respective logic to correct / cast the type in the 'convertToCorrectTypes' function
+ * 4. Add the normalized name of the validation type in the 'normalizedValidationOption' object
  */
 export const validationOptions: { name: ValidationType }[] = [
   { name: "phone" },
@@ -20,6 +21,12 @@ export const validationOptions: { name: ValidationType }[] = [
   { name: "url" },
   { name: "zip_code" },
 ];
+
+/**
+ * The normalized validation types available
+ * 
+ * Add a new entry to this when adding a new validation option to the 'validationOptions' array
+ */
 
 export const normalizedValidationOption = {
   phone: "Phone Number",


### PR DESCRIPTION
Normalizes the schema type to make it look nicer and more readable, for example zip_code becomes Zip Code, I could also display it like this "Zip Code (zip_code)" to keep the actual value visible.